### PR TITLE
feat: setting a charset schema meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="EN">
 
 <head>
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="theme-color" content="#317EFB"/>
     <link rel="manifest" href="manifest.json"/>

--- a/restaurant.html
+++ b/restaurant.html
@@ -2,6 +2,7 @@
 <html lang="EN">
 
 <head>
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#317EFB"/>
     <link rel="manifest" href="manifest.json"/>


### PR DESCRIPTION
feat: setting a charset schema meta tag

Based on an Udacity reviewer suggestion, I'm adding a meta tag with the UTF-8 charset

Resolves: #8